### PR TITLE
Revert reset password email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,5 @@
 class UserMailer < ActionMailer::Base
-  default from: "webmaster@kronos.nl"
+  default from: "Kronos <webmaster@kronos.nl>"
   
   def welcome_email(user, password)
       @user = user

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_api_v1_user_password_url(reset_password_token: @token, config: message['client-config'].to_s, redirect_url: message['redirect-url'].to_s) %></p>
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>


### PR DESCRIPTION
Temporary fix while React is not deployed. Should not be included when React is deployed. See issue #128 